### PR TITLE
Fix create command to process request body

### DIFF
--- a/src/services/Sample/Commands/Create/ICreateCase.ts
+++ b/src/services/Sample/Commands/Create/ICreateCase.ts
@@ -4,12 +4,7 @@ export class CreateCase {
   constructor(private DbProvider: IDbProvider) {}
 
   async execute(data: any) {
-    try {
-      const response = await this.DbProvider.insert(data);
-
-      return response;
-    } catch (error) {
-      return error;
-    }
+    const response = await this.DbProvider.insert(data);
+    return response;
   }
 }

--- a/src/services/Sample/Commands/Create/ICreateController.ts
+++ b/src/services/Sample/Commands/Create/ICreateController.ts
@@ -6,7 +6,7 @@ export class CreateController {
 
   async handle(request: Request, response: Response): Promise<Response> {
     try {
-      const data = await this.createCase.execute(request);
+      const data = await this.createCase.execute(request.body);
 
       return response.status(201).json(data);
     } catch (err) {


### PR DESCRIPTION
## Summary
- propagate database errors instead of swallowing them
- use the request body in CreateController

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883d5836a908322a499e6f5831d1f7a