### PR TITLE
docs: fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ REST API typescript template
 
 ## Funcionalidades
 
-- Eslint, Babel, Prittier and TS basic configs
-- Jest and Supetest basic configs
+- Eslint, Babel, Prettier and TS basic configs
+- Jest and Supertest basic configs
 - Routes, Services and Repositories and providers sample
 


### PR DESCRIPTION
## Summary
- correct Prettier and Supertest typos in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883d7ab5184832290d91fc2c1318b37